### PR TITLE
Add build helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ processes to speed up building:
 After the build is done, you'll find the build result in a folder called
 `output`, i.e. `output/sbemu.exe`.
 
+Alternatively you can run the provided helper script which downloads a
+DJGPP cross‑compiler on demand and builds SBEMU automatically:
+
+```bash
+./build.sh cross
+```
+
 ## Feature usage
 
 ### CD Audio

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+usage() {
+    echo "Usage: $0 cross" >&2
+    echo "  cross - build with a DJGPP cross compiler" >&2
+    exit 1
+}
+
+[ $# -eq 0 ] && usage
+
+target=$1
+
+ensure_djgpp_cross() {
+    if [ -x "djgpp-cross/bin/i586-pc-msdosdjgpp-gcc" ]; then
+        export PATH="$PWD/djgpp-cross/bin:$PATH"
+        return
+    fi
+    if command -v i586-pc-msdosdjgpp-gcc >/dev/null 2>&1; then
+        return
+    fi
+    echo "DJGPP cross tools not found. Downloading prebuilt toolchain..." >&2
+    tmpdir=$(mktemp -d)
+    url=$(curl -s https://api.github.com/repos/andrewwutw/build-djgpp/releases/latest \
+        | grep linux64 | grep browser_download_url | cut -d '"' -f4 | head -n1)
+    if [ -z "$url" ]; then
+        echo "Failed to determine DJGPP toolchain URL" >&2
+        exit 1
+    fi
+    mkdir -p djgpp-cross
+    curl -L "$url" -o "$tmpdir/djgpp.tar.bz2"
+    tar -xjf "$tmpdir/djgpp.tar.bz2" -C djgpp-cross --strip-components=1
+    rm -rf "$tmpdir"
+    if ! ldconfig -p | grep -q libfl.so.2; then
+        sudo apt-get update && sudo apt-get install -y libfl2
+    fi
+    export PATH="$PWD/djgpp-cross/bin:$PATH"
+}
+
+case "$target" in
+    cross)
+        if ! command -v make >/dev/null 2>&1; then
+            echo "make not found." >&2
+            exit 1
+        fi
+        ensure_djgpp_cross
+        make
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/scripts/install-djgpp.sh
+++ b/scripts/install-djgpp.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+PREFIX=${1:-/opt/djgpp}
+VERSION=v3.4
+ARCHIVE=djgpp-linux64-gcc1220.tar.bz2
+SHA256=8464f17017d6ab1b2bb2df4ed82357b5bf692e6e2b7fee37e315638f3d505f00
+URL="https://github.com/andrewwutw/build-djgpp/releases/download/${VERSION}/${ARCHIVE}"
+
+mkdir -p "$PREFIX"
+
+wget -O /tmp/${ARCHIVE} "$URL"
+echo "${SHA256}  /tmp/${ARCHIVE}" | shasum -a 256 --check
+tar -xf /tmp/${ARCHIVE} -C "$PREFIX" --strip-components=1
+rm /tmp/${ARCHIVE}
+
+echo "DJGPP cross compiler installed to ${PREFIX}."
+echo "Run 'source ${PREFIX}/setenv' to update your PATH."


### PR DESCRIPTION
## Summary
- add `build.sh` to automate compilation with a DJGPP cross compiler
- provide helper script to install the DJGPP toolchain
- mention the new script in the build instructions

## Testing
- `./build.sh cross`

------
https://chatgpt.com/codex/tasks/task_e_6862e33e43f8832c88dcefa7c2b65b79